### PR TITLE
ハッシュ変数に修正

### DIFF
--- a/templates/blog/20100118126425.html
+++ b/templates/blog/20100118126425.html
@@ -42,12 +42,12 @@ my @strs = ('  a', '  b', '   c');
 my @trimed = map { $_ =~ s/^\s+//; $_ } @strs;
 </pre>
 
-ひとつの要素をふたつの要素に変換することもできます。@keysが('a', 'b', 'c')の場合は@mappedは(a => 1, b => 1, c => 1)になります。
+ひとつの要素をふたつの要素に変換することもできます。@keysが('a', 'b', 'c')の場合は%mappedは(a => 1, b => 1, c => 1)になります。
 
 <pre>
 # ふたつの要素に変換
 my @keys = ('a', 'b', 'c');
-my @mapped = map { $_ => 1 } @keys;
+my %mapped = map { $_ => 1 } @keys;
 </pre>
 
 mapで書くことができるものはforeach文でも書くことができます。mapのほうが簡潔に記述できるのでPerlではよく利用されます。


### PR DESCRIPTION
元記事の@mappedをDumperで出力すると以下のようになります。
```
$VAR1 = [
          'a',
          1,
          'b',
          1,
          'c',
          1
        ];
```

%mappedとすると以下のようになるので、こちらの方がいいのかなと思いましたが、認識違いましたら却下していただけますと幸いです。
```
$VAR1 = {
          'c' => 1,
          'a' => 1,
          'b' => 1
        };
```